### PR TITLE
settings: gh apiをpermissions.allowに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,8 @@
       "Bash(gh issue comment *)",
       "Bash(gh issue edit *)",
       "Bash(gh label *)",
+      "Bash(gh api repos/ohyama4z/SomedayPockets/issues/*)",
+      "Bash(gh api repos/ohyama4z/SomedayPockets/issues/* *)",
       "Bash(gh pr view *)",
       "Bash(gh pr list *)",
       "Bash(gh pr create *)",


### PR DESCRIPTION
## Summary
- `settings.json` の `permissions.allow` に `gh api` パターンを追加
- epic機能のsub-issue操作時に確認プロンプトが出なくなる

Closes #43
