### PR TITLE
script: turn-counterの閾値を環境変数で設定可能にする

### DIFF
--- a/.claude/scripts/turn-counter.sh
+++ b/.claude/scripts/turn-counter.sh
@@ -3,7 +3,7 @@
 
 COUNTER_FILE="$(dirname "$0")/../tmp/turn-counter"
 mkdir -p "$(dirname "$COUNTER_FILE")"
-N=10
+N="${CLAUDE_REVIEW_INTERVAL:-10}"
 
 count=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
 count=$((count + 1))


### PR DESCRIPTION
## Summary
- `turn-counter.sh` の閾値を環境変数 `CLAUDE_REVIEW_INTERVAL` で上書き可能にする

Closes #48
