### PR TITLE
git worktreeを導入して並行作業を可能にする

### DIFF
--- a/.claude/skills/complete-task/SKILL.md
+++ b/.claude/skills/complete-task/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Bash(git branch *)
   - Bash(git push)
   - Bash(git push *)
+  - Bash(git worktree *)
   - Bash(gh pr ready *)
   - Bash(gh pr merge --merge *)
   - Bash(gh issue edit *)
@@ -91,7 +92,12 @@ gh issue view <番号> --repo ohyama4z/SomedayPockets --json state --jq .state
 gh issue close <番号> --repo ohyama4z/SomedayPockets
 ```
 
-## 11. mainに戻ってブランチを削除
+## 11. worktreeを削除してブランチを整理
+worktree内で作業している場合は、まずメインディレクトリに戻ってからworktreeを削除する：
+```bash
+git worktree remove .claude/worktrees/issue-<番号>
+```
+ブランチはマージ済みなので削除する：
 ```bash
 git checkout main
 git pull

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -9,9 +9,11 @@ allowed-tools:
   - Bash(gh pr create *)
   - Bash(git checkout *)
   - Bash(git pull)
+  - Bash(git branch *)
   - Bash(git commit *)
   - Bash(git push)
   - Bash(git push *)
+  - Bash(git worktree *)
   - Bash(ls *)
   - Read
   - Write
@@ -33,11 +35,15 @@ git checkout main
 git pull
 ```
 
-## 3. 作業ブランチを作成
-Issueのタイトルから簡潔な英語名をつける：
+## 3. 作業ブランチとworktreeを作成
+Issueのタイトルから簡潔な英語名をつける。ブランチを作成し、worktreeを切る：
 ```bash
-git checkout -b issue/$ARGUMENTS-<簡潔な名前>
+git branch issue/$ARGUMENTS-<簡潔な名前> main
+git worktree add .claude/worktrees/issue-$ARGUMENTS issue/$ARGUMENTS-<簡潔な名前>
 ```
+以降の操作（コミット・push等）はworktreeディレクトリ内で実行する。
+- worktreeのパス: `.claude/worktrees/issue-$ARGUMENTS`
+- Bashコマンドには `-C` オプション（`git -C <path>`）か、`--git-dir` を使ってworktree内で実行する
 
 ## 4. in-progressラベルを付与
 ```bash
@@ -62,10 +68,10 @@ gh issue comment $ARGUMENTS --repo ohyama4z/SomedayPockets --body-file tmp/gh-bo
 ```
 
 ## 7. 初回pushしてドラフトPRを作成
-空コミットを作成し、pushしてからドラフトPRを作成する：
+worktreeディレクトリ内で空コミットを作成し、pushしてからドラフトPRを作成する：
 ```bash
-git commit --allow-empty -m "chore: Issue #$ARGUMENTS の作業開始"
-git push -u origin HEAD
+git -C .claude/worktrees/issue-$ARGUMENTS commit --allow-empty -m "chore: Issue #$ARGUMENTS の作業開始"
+git -C .claude/worktrees/issue-$ARGUMENTS push -u origin HEAD
 ```
 PR本文は `.github/pull_request_template.md` をベースに `tmp/gh-body.md` に書いてから作成する：
 ```bash
@@ -76,6 +82,7 @@ gh pr create --repo ohyama4z/SomedayPockets --draft --title "<タイトル>" --b
 - 作成したブランチ名
 - ドラフトPRのURL
 - 作業計画の概要
+- worktreeパス（別ターミナルで `cd <path>` → `claude` で並行作業可能）
 
 ## 補足: epic
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build/
 # Temp files for Claude Code
 /tmp/
 /.claude/tmp/
+
+# Git worktrees for parallel sessions
+/.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@
 - epic完了時: 親Issueをクローズし、完了サマリー（主要な判断経緯・参照ADR・知見リンク）をIssueコメントに残す
 - 詳細は `docs/decisions/004-epicを親Issue+ラベルで管理する.md` を参照
 
+## 並行作業（git worktree）
+- `/start-task` はworktreeを `.claude/worktrees/issue-<番号>` に自動作成する
+- 並行作業の手順:
+  1. `/start-task <番号>` を実行する（ブランチ作成・worktree作成・PR作成まで一括）
+  2. 別ターミナルで `cd .claude/worktrees/issue-<番号>` → `claude` で作業開始
+- worktree削除: `git worktree remove .claude/worktrees/issue-<番号>`
+- メインディレクトリは常に `main` ブランチに留める
+
 ## 改善提案
 - 運用・開発プロセス・Claude Codeの活用方法について、気づいた改善点はその都度積極的に提案する
 


### PR DESCRIPTION
## Summary
git worktreeを使った並行作業の運用ルールを整備し、CLAUDE.md・スキルに反映する。

Closes #59
