### PR TITLE
knowledge/INDEX.mdによる知見参照の効率化 (#45)

### DIFF
--- a/.claude/skills/save-knowledge/SKILL.md
+++ b/.claude/skills/save-knowledge/SKILL.md
@@ -44,8 +44,12 @@ ls knowledge/
 （1つのトピックに絞って簡潔に記述）
 ```
 
-## 4. コミット
+## 4. INDEX.mdを更新
+`knowledge/INDEX.md` のテーブルに新しいファイルのエントリを追加する。サマリーは知見の核心を1行で表す。
+
+## 5. コミット
 ```bash
 git add knowledge/ファイル名
+git add knowledge/INDEX.md
 git commit -m "knowledge: タイトル"
 ```

--- a/.claude/skills/session-status/SKILL.md
+++ b/.claude/skills/session-status/SKILL.md
@@ -31,10 +31,8 @@ gh issue view <番号> --repo ohyama4z/SomedayPockets --comments
 ```
 
 ## 3. 知見を読み込む
-`knowledge/` 配下のファイル一覧を確認し、直近の知見や今後の作業に関連しそうなものがあれば読み込む。
-```bash
-ls knowledge/
-```
+`knowledge/INDEX.md` を読み、今回の作業に関連しそうなファイルがあればその本文を読み込む。
+INDEXが存在しない場合は `ls knowledge/` にフォールバックする。
 
 ## 4. Gitの状態を確認
 ```bash

--- a/knowledge/INDEX.md
+++ b/knowledge/INDEX.md
@@ -1,0 +1,13 @@
+# knowledge/ インデックス
+
+| ファイル | サマリー |
+|---------|---------|
+| 2026-03-10_T3_1_要件定義の磨き込み.md | ユーザーの現運用を聞いて要件を逆算する。コア体験の言語化が重要 |
+| 2026-03-10_T4_1_技術スタック選定.md | Next.js + Cloudflare（D1/Access/Pages）+ Drizzle ORMの選定理由と制約 |
+| 2026-03-14_T28_1_SKILL.mdフロントマターの仕様.md | SKILL.mdでサポートされる属性一覧。allowed-toolsは未サポート |
+| 2026-03-14_T28_2_カスタムサブエージェントの定義方法.md | .claude/agents/にmdファイルを置きAgentツールでsubagent_type指定で起動 |
+| 2026-03-14_T28_3_Stopフックによる定期プロンプト.md | hooks.Stopでシェル出力をプロンプト注入する仕組み |
+| 2026-03-14_T28_4_allowed-toolsはランタイム未強制.md | SKILL.mdのallowed-toolsは実行時に制限されない（バグ） |
+| 2026-03-14_T28_5_permissions.allowにスキル用コマンドも必要.md | スキル内Bashコマンドもsettings.jsonのpermissions.allowに必要 |
+| 2026-03-14_T36_1_Claude_Code権限設計.md | permissions設計原則、&&チェーンの制約、deny優先ルール |
+| 2026-03-15_T40_1_GitHub_sub-issue_API.md | gh apiでsub-issueを操作する方法（内部IDが必要） |


### PR DESCRIPTION
## Summary
- `knowledge/INDEX.md` を導入し、各知見ファイルの1行サマリーをテーブル管理
- `session-status` スキルをINDEX.md読み込み方式に変更（ファイル数増加時のコンテキスト消費を抑制）
- `save-knowledge` スキルにINDEX.md更新ステップを追加

Closes #45
