### PR TITLE
refactor: start-task/complete-taskの定型処理をシェルスクリプトに切り出し

### DIFF
--- a/.claude/scripts/complete-task.sh
+++ b/.claude/scripts/complete-task.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# complete-task.sh - タスク完了の定型処理（PRマージ・worktree削除・Issue管理）
+# 使い方: bash .claude/scripts/complete-task.sh <Issue番号>
+
+set -euo pipefail
+
+REPO="ohyama4z/SomedayPockets"
+ISSUE_NUM="${1:?Issue番号を指定してください}"
+WORKTREE_PATH=".claude/worktrees/issue-${ISSUE_NUM}"
+
+echo "=== complete-task: Issue #${ISSUE_NUM} ==="
+
+# --- 1. ブランチ名を特定 ---
+if [ -d "$WORKTREE_PATH" ]; then
+  BRANCH_NAME=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD)
+else
+  # worktreeがない場合はブランチ名をパターンで探す
+  BRANCH_NAME=$(git branch --list "issue/${ISSUE_NUM}-*" --format='%(refname:short)' | head -1)
+fi
+
+if [ -z "$BRANCH_NAME" ]; then
+  echo "エラー: Issue #${ISSUE_NUM} に対応するブランチが見つかりません" >&2
+  exit 1
+fi
+
+echo "ブランチ: ${BRANCH_NAME}"
+
+# --- 2. in-progressラベルを除去 ---
+echo "--- in-progressラベルを除去 ---"
+gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "in-progress" || true
+
+# --- 3. ドラフトPRをReadyにする ---
+echo "--- PRをReadyに変更 ---"
+gh pr ready "$BRANCH_NAME" --repo "$REPO"
+
+# --- 4. PRをマージ ---
+echo "--- PRをマージ ---"
+gh pr merge "$BRANCH_NAME" --merge --repo "$REPO"
+
+# --- 5. Issueのクローズ確認 ---
+echo "--- Issueのクローズ確認 ---"
+ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state --jq .state)
+if [ "$ISSUE_STATE" = "OPEN" ]; then
+  echo "Issueが自動クローズされなかったため、手動でクローズします"
+  gh issue close "$ISSUE_NUM" --repo "$REPO"
+fi
+
+# --- 6. worktreeを削除 ---
+echo "--- worktreeを削除 ---"
+if [ -d "$WORKTREE_PATH" ]; then
+  git worktree remove "$WORKTREE_PATH"
+else
+  echo "worktreeは既に削除されています"
+fi
+
+# --- 7. mainに戻ってブランチを整理 ---
+echo "--- mainブランチに切り替え・ブランチ削除 ---"
+git checkout main
+git pull
+git branch -d "$BRANCH_NAME" || true
+
+echo "=== 完了 ==="
+echo "Issue #${ISSUE_NUM} をクローズしました"
+echo "ブランチ ${BRANCH_NAME} を削除しました"

--- a/.claude/scripts/start-task.sh
+++ b/.claude/scripts/start-task.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# start-task.sh - タスク着手の定型処理（ブランチ作成・worktree・PR作成）
+# 使い方: bash .claude/scripts/start-task.sh <Issue番号>
+
+set -euo pipefail
+
+REPO="ohyama4z/SomedayPockets"
+ISSUE_NUM="${1:?Issue番号を指定してください}"
+
+# --- 危険コマンドのガード ---
+# このスクリプト自体は安全な操作のみ行うが、念のためシェル環境を制限
+# （スクリプト内では外部入力をコマンドとして実行しないため問題ない）
+
+# --- 1. Issueタイトルを取得してブランチ名を生成 ---
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json title --jq .title)
+if [ -z "$ISSUE_TITLE" ]; then
+  echo "エラー: Issue #${ISSUE_NUM} のタイトルを取得できませんでした" >&2
+  exit 1
+fi
+
+# タイトルをslugify: 小文字化、英数字以外をハイフンに、連続ハイフン統合、先頭末尾ハイフン除去
+SLUG=$(echo "$ISSUE_TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/[^a-z0-9]/-/g' \
+  | sed 's/-\+/-/g' \
+  | sed 's/^-//;s/-$//' \
+  | cut -c1-50)
+
+BRANCH_NAME="issue/${ISSUE_NUM}-${SLUG}"
+WORKTREE_PATH=".claude/worktrees/issue-${ISSUE_NUM}"
+
+echo "=== start-task: Issue #${ISSUE_NUM} ==="
+echo "ブランチ: ${BRANCH_NAME}"
+echo "worktree: ${WORKTREE_PATH}"
+
+# --- 2. mainブランチを最新にする ---
+echo "--- mainブランチを最新化 ---"
+git checkout main
+git pull
+
+# --- 3. ブランチとworktreeを作成 ---
+echo "--- ブランチとworktreeを作成 ---"
+git branch "$BRANCH_NAME" main
+git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+
+# --- 4. in-progressラベルを付与 ---
+echo "--- in-progressラベルを付与 ---"
+gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-label "in-progress"
+
+# --- 5. 空コミットを作成してpush ---
+echo "--- 初回push ---"
+git -C "$WORKTREE_PATH" commit --allow-empty -m "chore: Issue #${ISSUE_NUM} の作業開始"
+git -C "$WORKTREE_PATH" push -u origin HEAD
+
+# --- 6. ドラフトPRを作成 ---
+echo "--- ドラフトPRを作成 ---"
+PR_BODY="## Summary
+${ISSUE_TITLE}
+
+Closes #${ISSUE_NUM}"
+
+PR_URL=$(gh pr create \
+  --repo "$REPO" \
+  --head "$BRANCH_NAME" \
+  --draft \
+  --title "${ISSUE_TITLE}" \
+  --body "$PR_BODY")
+
+echo "=== 完了 ==="
+echo "PR: ${PR_URL}"
+echo "worktree: ${WORKTREE_PATH}"
+echo "ブランチ: ${BRANCH_NAME}"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,8 @@
       "Bash(git push *)",
       "Bash(git worktree *)",
       "Bash(git -C *)",
+      "Bash(bash .claude/scripts/start-task.sh *)",
+      "Bash(bash .claude/scripts/complete-task.sh *)",
       "WebSearch",
       "WebFetch",
       "Edit(/notes/**)",

--- a/.claude/skills/complete-task/SKILL.md
+++ b/.claude/skills/complete-task/SKILL.md
@@ -2,17 +2,10 @@
 name: complete-task
 description: 現在の作業ブランチのドラフトPRをReadyにしてmainにマージし、タスクを完了する
 allowed-tools:
+  - Bash(bash .claude/scripts/complete-task.sh *)
   - Bash(git status)
   - Bash(git log *)
-  - Bash(git checkout *)
-  - Bash(git pull)
-  - Bash(git branch *)
-  - Bash(git push)
-  - Bash(git push *)
-  - Bash(git worktree *)
-  - Bash(gh pr ready *)
-  - Bash(gh pr merge --merge *)
-  - Bash(gh issue edit *)
+  - Bash(git -C *)
   - Bash(gh issue view *)
   - Bash(gh issue comment *)
   - Read
@@ -63,48 +56,17 @@ epicタスクの場合、ステップ5で完了サマリーの投稿が必要。
 gh issue comment <番号> --repo ohyama4z/SomedayPockets --body-file tmp/gh-body.md
 ```
 
-## 6. in-progressラベルを除去
-```bash
-gh issue edit <番号> --repo ohyama4z/SomedayPockets --remove-label "in-progress"
-```
-
-## 7. プロセスレビュー
+## 6. プロセスレビュー
 `/review-process` スキルを実行する。見つかった改善点はIssue起票のみ行い、PRマージはブロックしない。
 
-## 8. ドラフトPRをReadyに変更
+## 7. 定型処理を実行
+in-progressラベル除去・PRをReady・マージ・worktree削除・ブランチ整理を一括実行する：
 ```bash
-gh pr ready --repo ohyama4z/SomedayPockets
-```
-
-## 9. PRをマージ
-```bash
-gh pr merge --merge --repo ohyama4z/SomedayPockets
+bash .claude/scripts/complete-task.sh <番号>
 ```
 マージによりIssueが自動クローズされる（PR本文の `Closes #番号` による）。
 
-## 10. Issueのクローズ確認
-マージ後にIssueが自動クローズされたか確認する：
-```bash
-gh issue view <番号> --repo ohyama4z/SomedayPockets --json state --jq .state
-```
-`OPEN` のままであれば手動でクローズする：
-```bash
-gh issue close <番号> --repo ohyama4z/SomedayPockets
-```
-
-## 11. worktreeを削除してブランチを整理
-worktree内で作業している場合は、まずメインディレクトリに戻ってからworktreeを削除する：
-```bash
-git worktree remove .claude/worktrees/issue-<番号>
-```
-ブランチはマージ済みなので削除する：
-```bash
-git checkout main
-git pull
-git branch -d <ブランチ名>
-```
-
-## 12. 報告
+## 8. 報告
 - マージされたPRのURL
 - クローズされたIssue番号
 - プロセスレビューで起票した提案があればそのURL

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -3,17 +3,9 @@ name: start-task
 description: Issue番号を指定してタスクに着手する。ブランチ作成・ドラフトPR・ラベル付与・作業計画コメントを一括実行
 argument-hint: "[issue番号]"
 allowed-tools:
+  - Bash(bash .claude/scripts/start-task.sh *)
   - Bash(gh issue view *)
-  - Bash(gh issue edit *)
   - Bash(gh issue comment *)
-  - Bash(gh pr create *)
-  - Bash(git checkout *)
-  - Bash(git pull)
-  - Bash(git branch *)
-  - Bash(git commit *)
-  - Bash(git push)
-  - Bash(git push *)
-  - Bash(git worktree *)
   - Bash(ls *)
   - Read
   - Write
@@ -29,35 +21,20 @@ Issue #$ARGUMENTS に着手する。以下を順に実行：
 gh issue view $ARGUMENTS --repo ohyama4z/SomedayPockets
 ```
 
-## 2. mainブランチを最新にする
+## 2. 定型処理を実行
+ブランチ作成・worktree作成・in-progressラベル付与・初回push・ドラフトPR作成を一括実行する：
 ```bash
-git checkout main
-git pull
+bash .claude/scripts/start-task.sh $ARGUMENTS
 ```
 
-## 3. 作業ブランチとworktreeを作成
-Issueのタイトルから簡潔な英語名をつける。ブランチを作成し、worktreeを切る：
-```bash
-git branch issue/$ARGUMENTS-<簡潔な名前> main
-git worktree add .claude/worktrees/issue-$ARGUMENTS issue/$ARGUMENTS-<簡潔な名前>
-```
-以降の操作（コミット・push等）はworktreeディレクトリ内で実行する。
-- worktreeのパス: `.claude/worktrees/issue-$ARGUMENTS`
-- Bashコマンドには `-C` オプション（`git -C <path>`）か、`--git-dir` を使ってworktree内で実行する
-
-## 4. in-progressラベルを付与
-```bash
-gh issue edit $ARGUMENTS --repo ohyama4z/SomedayPockets --add-label "in-progress"
-```
-
-## 5. 知見を読み込む
+## 3. 知見を読み込む
 `knowledge/` 配下のファイル一覧を確認し、今回のタスクに参考になりそうな知見があれば読み込む。
 ```bash
 ls knowledge/
 ```
 関連しそうなファイルがあれば内容を読み、作業計画に活かす。
 
-## 6. 作業計画を立て、Issueにコメント
+## 4. 作業計画を立て、Issueにコメント
 Issue内容を踏まえて作業計画を立てる。サブタスクはチェックリスト（`- [ ]`）で分解する。
 - 粒度が大きいサブタスクは子Issueに切り出し、`- [ ] #番号` でリンクする
 - 小さいサブタスクはチェックリストのままで管理する
@@ -67,18 +44,7 @@ Issue内容を踏まえて作業計画を立てる。サブタスクはチェッ
 gh issue comment $ARGUMENTS --repo ohyama4z/SomedayPockets --body-file tmp/gh-body.md
 ```
 
-## 7. 初回pushしてドラフトPRを作成
-worktreeディレクトリ内で空コミットを作成し、pushしてからドラフトPRを作成する：
-```bash
-git -C .claude/worktrees/issue-$ARGUMENTS commit --allow-empty -m "chore: Issue #$ARGUMENTS の作業開始"
-git -C .claude/worktrees/issue-$ARGUMENTS push -u origin HEAD
-```
-PR本文は `.github/pull_request_template.md` をベースに `tmp/gh-body.md` に書いてから作成する：
-```bash
-gh pr create --repo ohyama4z/SomedayPockets --draft --title "<タイトル>" --body-file tmp/gh-body.md
-```
-
-## 8. ユーザーに報告
+## 5. ユーザーに報告
 - 作成したブランチ名
 - ドラフトPRのURL
 - 作業計画の概要


### PR DESCRIPTION
## Summary
start-task/complete-taskスキルのSKILL.mdに記述されていたgitコマンド群を `.claude/scripts/start-task.sh` と `complete-task.sh` に切り出し、SKILL.mdからはスクリプト呼び出しに置き換えた。

Closes #72